### PR TITLE
Update repository references for rename to ably-pubsub-python

### DIFF
--- a/.ably/capabilities.yaml
+++ b/.ably/capabilities.yaml
@@ -54,7 +54,7 @@ compliance:
         Subscribe:
       Release:
       Status:
-        Channel Details: # https://github.com/ably/ably-python/pull/276
+        Channel Details: # https://github.com/ably/ably-pubsub-python/pull/276
     Opaque Request:
     Push Notifications Administration:
       Channel Subscription:

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -30,16 +30,16 @@ Then perform these steps in order:
    ```
    Filter the PRs to only those merged after that tag date. Format each as:
    ```
-   - Short, one sentence summary from PR title and description [#NUMBER](https://github.com/ably/ably-java/pull/NUMBER)
+   - Short, one sentence summary from PR title and description [#NUMBER](https://github.com/ably/ably-pubsub-python/pull/NUMBER)
    ```
    If the tag doesn't exist or there are no merged PRs, use a single `-` placeholder bullet instead.
 
 4. In `CHANGELOG.md`, insert the following block immediately after the `# Change Log` heading (and its trailing blank line), before the first existing `## [` version entry:
 
 ```
-## [NEW_VERSION](https://github.com/ably/ably-java/tree/vNEW_VERSION)
+## [NEW_VERSION](https://github.com/ably/ably-pubsub-python/tree/vNEW_VERSION)
 
-[Full Changelog](https://github.com/ably/ably-java/compare/vOLD_VERSION...vNEW_VERSION)
+[Full Changelog](https://github.com/ably/ably-pubsub-python/compare/vOLD_VERSION...vNEW_VERSION)
 
 ### What's Changed
 

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -16,5 +16,5 @@ jobs:
       id-token: write      # aws-actions/configure-aws-credentials (OIDC)
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
-      repository-name: ably-python
+      repository-name: ably-pubsub-python
     secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to ably-python
+# Contributing to ably-pubsub-python
 
 ## Contributing
 
 ### Initialising
 
-ably-python uses [uv](https://docs.astral.sh/uv/) for packaging and dependency management. Please refer to the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/) for up to date instructions on how to install uv.
+ably-pubsub-python uses [uv](https://docs.astral.sh/uv/) for packaging and dependency management. Please refer to the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/) for up to date instructions on how to install uv.
 
 Perform the following operations after cloning the repository contents:
 
@@ -29,7 +29,7 @@ uv run pytest
 4. Create a release PR (ensure you include an SDK Team Engineering Lead and the SDK Team Product Manager as reviewers) and gain approvals for it, then merge that to `main`
 5. Create a tag named like `v2.0.1` and push it to GitHub - e.g. `git tag v2.0.1 && git push origin v2.0.1`
 6. Create the release on GitHub including populating the release notes
-7. Go to the [Release Workflow](https://github.com/ably/ably-python/actions/workflows/release.yml) and ask [ably/team-sdk](https://github.com/orgs/ably/teams/team-sdk) member to approve publishing to the PyPI registry
+7. Go to the [Release Workflow](https://github.com/ably/ably-pubsub-python/actions/workflows/release.yml) and ask [ably/team-sdk](https://github.com/orgs/ably/teams/team-sdk) member to approve publishing to the PyPI registry
 8. Update the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)) with these changes
 
 ## Release Process (Manual)
@@ -42,7 +42,7 @@ The release process must include the following steps:
 2. Create a release branch named like `release/2.0.1`
 3. Add a commit to bump the version number, updating [`pyproject.toml`](./pyproject.toml) and [`ably/__init__.py`](./ably/__init__.py)
 4. Run [`github_changelog_generator`](https://github.com/github-changelog-generator/github-changelog-generator) to automate the update of the [CHANGELOG](./CHANGELOG.md). This may require some manual intervention, both in terms of how the command is run and how the change log file is modified. Your mileage may vary:
-   - The command you will need to run will look something like this: `github_changelog_generator -u ably -p ably-python --since-tag v2.0.0 --output delta.md --token $GITHUB_TOKEN_WITH_REPO_ACCESS`. Generate token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token).
+   - The command you will need to run will look something like this: `github_changelog_generator -u ably -p ably-pubsub-python --since-tag v2.0.0 --output delta.md --token $GITHUB_TOKEN_WITH_REPO_ACCESS`. Generate token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token).
    - Using the command above, `--output delta.md` writes changes made after `--since-tag` to a new file
    - The contents of that new file (`delta.md`) then need to be manually inserted at the top of the `CHANGELOG.md`, changing the "Unreleased" heading and linking with the current version numbers
    - Also ensure that the "Full Changelog" link points to the new version tag instead of the `HEAD`
@@ -51,10 +51,10 @@ The release process must include the following steps:
 7. Create a release PR (ensure you include an SDK Team Engineering Lead and the SDK Team Product Manager as reviewers) and gain approvals for it, then merge that to `main`
 8. Create a tag named like `v2.0.1` and push it to GitHub - e.g. `git tag v2.0.1 && git push origin v2.0.1`
 9. Create the release on GitHub including populating the release notes
-10. Go to the [Release Workflow](https://github.com/ably/ably-python/actions/workflows/release.yml) and ask [ably/team-sdk](https://github.com/orgs/ably/teams/team-sdk) member to approve publishing to the PyPI registry
+10. Go to the [Release Workflow](https://github.com/ably/ably-pubsub-python/actions/workflows/release.yml) and ask [ably/team-sdk](https://github.com/orgs/ably/teams/team-sdk) member to approve publishing to the PyPI registry
 11. Update the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)) with these changes
 
 We tend to use [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator) to collate the information required for a change log update.
 Your mileage may vary, but it seems the most reliable method to invoke the generator is something like:
-`github_changelog_generator -u ably -p ably-python --since-tag v1.0.0 --output delta.md`
+`github_changelog_generator -u ably -p ably-pubsub-python --since-tag v1.0.0 --output delta.md`
 and then manually merge the delta contents in to the main change log (where `v1.0.0` in this case is the tag for the previous release).

--- a/LONG_DESCRIPTION.rst
+++ b/LONG_DESCRIPTION.rst
@@ -16,5 +16,5 @@ Using Ably for Python
 ---------------------
 
 - Sign up for Ably at https://ably.com/sign-up
-- Get usage examples at https://github.com/ably/ably-python
+- Get usage examples at https://github.com/ably/ably-pubsub-python
 - Visit https://ably.com/docs for a complete API reference and more examples

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Ably Pub/Sub Python Header](images/pythonSDK-github.png)
 [![PyPI version](https://badge.fury.io/py/ably.svg)](https://pypi.org/project/ably/)
-[![License](https://img.shields.io/github/license/ably/ably-python)](https://github.com/ably/ably-python/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/ably/ably-pubsub-python)](https://github.com/ably/ably-pubsub-python/blob/main/LICENSE)
 
 
 # Ably Pub/Sub Python SDK
@@ -80,7 +80,7 @@ async with AblyRealtime('your-ably-api-key', client_id='me') as realtime_client:
 
 ## Releases
 
-The [CHANGELOG.md](https://github.com/ably/ably-python/blob/main/CHANGELOG.md) contains details of the latest releases for this SDK. You can also view all Ably releases on [changelog.ably.com](https://changelog.ably.com).
+The [CHANGELOG.md](https://github.com/ably/ably-pubsub-python/blob/main/CHANGELOG.md) contains details of the latest releases for this SDK. You can also view all Ably releases on [changelog.ably.com](https://changelog.ably.com).
 
 ---
 
@@ -92,7 +92,7 @@ Read the [CONTRIBUTING.md](./CONTRIBUTING.md) guidelines to contribute to Ably.
 
 ## Support, feedback, and troubleshooting
 
-For help or technical support, visit Ably's [support page](https://ably.com/support) or [GitHub Issues](https://github.com/ably/ably-python/issues) for community-reported bugs and discussions.
+For help or technical support, visit Ably's [support page](https://ably.com/support) or [GitHub Issues](https://github.com/ably/ably-pubsub-python/issues) for community-reported bugs and discussions.
 
 ### Full Realtime support unavailable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ unasync = "ably.scripts.unasync:run"
 
 [project.urls]
 Homepage = "https://ably.com"
-Repository = "https://github.com/ably/ably-python"
+Repository = "https://github.com/ably/ably-pubsub-python"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Why

[PDR-091b](https://ably.atlassian.net/wiki/spaces/product/pages/5362810886) renames this repository `ably-python` → `ably-pubsub-python`. This PR updates every internal reference tied to the repository's identity so it can land in the rename freeze window.

## What changed

- `.github/workflows/features.yml` — `repository-name: ably-python` → `ably-pubsub-python`. This selects the per-repo IAM role assumed via OIDC for the features-report upload; the new `ably-sdk-builds-ably-pubsub-python` role is already provisioned ([infrastructure#13005](https://github.com/ably/infrastructure/pull/13005), merged 2026-09-01).
- `pyproject.toml` — `[project.urls] Repository`.
- `README.md` — license badge and link, CHANGELOG link, GitHub Issues link.
- `LONG_DESCRIPTION.rst` — usage-examples link (rendered on PyPI).
- `CONTRIBUTING.md` — title/intro, both release-workflow links, and the `github_changelog_generator -p` project flag (3 occurrences).
- `.ably/capabilities.yaml` — PR link.
- `.claude/skills/release/SKILL.md` — CHANGELOG link templates, which pointed at `ably-java`; now `ably-pubsub-python`.

`uv run ruff check` passes and `pytest test/unit` is green (75 passed).

## ⚠️ Merge only in the rename freeze window

**Merge immediately after the repository is renamed, not before.** Merging early breaks two things:

- `features.yml` — the new IAM role's OIDC trust is bound to `repo:ably/ably-pubsub-python`, so the subject won't match until the rename happens, and the credentials step fails (the upload failure mode is otherwise silent, so verify the upload actually lands post-merge).
- The README license badge, which resolves against a repository name that doesn't exist yet.

Conversely, once the rename happens the *old* `repository-name` stops matching, so this is a same-window change in both directions.

## What this PR deliberately does not do

- **The `ably-python/<version>` `Ably-Agent` identifier** (`ably/http/httputils.py`) — a registered agent identifier, not a repository reference. The legacy `ably` distribution must keep sending it; the family rename to `ably-pubsub-python` happens only in the new major on `integration/v4` (plan step 14b).
- **Historical `CHANGELOG.md` / `UPDATING.md` entries** and issue links in tests and code comments — GitHub's rename redirect covers all of them, and rewriting history entries is churn.
- **PyPI / TestPyPI trusted-publisher rebinds** — the legacy `ably` project's publisher is bound to `ably/ably-python` and must be re-pointed registry-side, plus the pending publishers for the new distributions. Registry work, not repo work; see plan steps 16/17/25.

Mirrors [ably-ruby#457](https://github.com/ably/ably-ruby/pull/457).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
