### PR TITLE
fix: reset the pending ping after a timeout so later ping() calls succeed

### DIFF
--- a/ably/realtime/connectionmanager.py
+++ b/ably/realtime/connectionmanager.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import deque
-from datetime import datetime
 from itertools import zip_longest
 from typing import TYPE_CHECKING
 
@@ -125,7 +125,7 @@ class ConnectionManager(EventEmitter):
         self.options = realtime.options
         self.__ably = realtime
         self.__state: ConnectionState = initial_state
-        self.__ping_future: asyncio.Future | None = None
+        self.__pending_pings: dict[str, asyncio.Future[None]] = {}
         self.__timeout_in_secs: float = self.options.realtime_request_timeout / 1000
         self.transport: WebSocketTransport | None = None
         self.__connection_details: ConnectionDetails | None = None
@@ -332,29 +332,21 @@ class ConnectionManager(EventEmitter):
             self.pending_message_queue.complete_all_messages(error)
 
     async def ping(self) -> float:
-        if self.__ping_future:
-            try:
-                response = await self.__ping_future
-            except asyncio.CancelledError:
-                raise AblyException("Ping request cancelled due to request timeout", 504, 50003) from None
-            return response
+        if self.__state not in (ConnectionState.CONNECTED, ConnectionState.CONNECTING):
+            raise AblyException("Cannot send ping request. Calling ping in invalid state", 400, 40000)
 
-        self.__ping_future = asyncio.Future()
-        if self.__state in [ConnectionState.CONNECTED, ConnectionState.CONNECTING]:
-            self.__ping_id = get_random_id()
-            ping_start_time = datetime.now().timestamp()
-            await self.send_protocol_message({"action": ProtocolMessageAction.HEARTBEAT,
-                                              "id": self.__ping_id})
-        else:
-            raise AblyException("Cannot send ping request. Calling ping in invalid state", 40000, 400)
+        # RTN13e: the id tells this ping's echo apart from server heartbeats and other pings
+        ping_id = get_random_id()
+        echo = self.__pending_pings[ping_id] = asyncio.get_running_loop().create_future()
+        start_time = time.monotonic()
         try:
-            await asyncio.wait_for(self.__ping_future, self.__timeout_in_secs)
+            await self.send_protocol_message({"action": ProtocolMessageAction.HEARTBEAT, "id": ping_id})
+            await asyncio.wait_for(echo, self.__timeout_in_secs)
         except asyncio.TimeoutError:
             raise AblyException("Timeout waiting for ping response", 504, 50003) from None
-
-        ping_end_time = datetime.now().timestamp()
-        response_time_ms = (ping_end_time - ping_start_time) * 1000
-        return round(response_time_ms, 2)
+        finally:
+            self.__pending_pings.pop(ping_id, None)
+        return round((time.monotonic() - start_time) * 1000, 2)
 
     def on_connected(self, connection_details: ConnectionDetails, connection_id: str,
                      reason: AblyException | None = None) -> None:
@@ -458,12 +450,10 @@ class ConnectionManager(EventEmitter):
         self.__ably.channels._on_channel_message(msg)
 
     def on_heartbeat(self, id: str | None) -> None:
-        if self.__ping_future:
-            # Resolve on heartbeat from ping request.
-            if self.__ping_id == id:
-                if not self.__ping_future.cancelled():
-                    self.__ping_future.set_result(None)
-                self.__ping_future = None
+        echo = self.__pending_pings.pop(id, None)
+        # the echo can arrive while wait_for is still cancelling a timed-out ping
+        if echo is not None and not echo.done():
+            echo.set_result(None)
 
     def on_ack(
         self, serial: int, count: int, res: list[PublishResult] | None

--- a/ably/realtime/connectionmanager.py
+++ b/ably/realtime/connectionmanager.py
@@ -150,6 +150,17 @@ class ConnectionManager(EventEmitter):
         if reason:
             self.__error_reason = reason
 
+        # A heartbeat echo cannot arrive once the connection is no longer connected,
+        # so fail pending pings now rather than letting them run to the request timeout
+        if state in (
+            ConnectionState.DISCONNECTED,
+            ConnectionState.SUSPENDED,
+            ConnectionState.CLOSING,
+            ConnectionState.CLOSED,
+            ConnectionState.FAILED,
+        ):
+            self.__fail_pending_pings(reason or ConnectionErrors[state])
+
         # RTN16d: Clear connection state when entering SUSPENDED or terminal states
         if state == ConnectionState.SUSPENDED or state in (
             ConnectionState.CLOSED,
@@ -454,6 +465,12 @@ class ConnectionManager(EventEmitter):
         # the echo can arrive while wait_for is still cancelling a timed-out ping
         if echo is not None and not echo.done():
             echo.set_result(None)
+
+    def __fail_pending_pings(self, error: AblyException) -> None:
+        pending, self.__pending_pings = self.__pending_pings, {}
+        for echo in pending.values():
+            if not echo.done():
+                echo.set_exception(error)
 
     def on_ack(
         self, serial: int, count: int, res: list[PublishResult] | None

--- a/ably/realtime/connectionmanager.py
+++ b/ably/realtime/connectionmanager.py
@@ -120,12 +120,29 @@ class PendingMessageQueue:
         self.messages.clear()
 
 
+class PendingPing:
+    """Represents a ping awaiting its heartbeat echo from the server"""
+
+    def __init__(self, id: str):
+        self.id = id
+        self.future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        self.start_time: float = time.monotonic()
+
+    @property
+    def message(self) -> dict:
+        return {"action": ProtocolMessageAction.HEARTBEAT, "id": self.id}
+
+    @property
+    def response_time_ms(self) -> float:
+        return round((time.monotonic() - self.start_time) * 1000, 2)
+
+
 class ConnectionManager(EventEmitter):
     def __init__(self, realtime: AblyRealtime, initial_state):
         self.options = realtime.options
         self.__ably = realtime
         self.__state: ConnectionState = initial_state
-        self.__pending_pings: dict[str, asyncio.Future[None]] = {}
+        self.__pending_pings: dict[str, PendingPing] = {}
         self.__timeout_in_secs: float = self.options.realtime_request_timeout / 1000
         self.transport: WebSocketTransport | None = None
         self.__connection_details: ConnectionDetails | None = None
@@ -150,10 +167,9 @@ class ConnectionManager(EventEmitter):
         if reason:
             self.__error_reason = reason
 
-        # A heartbeat echo cannot arrive once the connection is no longer connected,
-        # so fail pending pings now rather than letting them run to the request timeout
+        # RTN13b: a ping cannot complete from these states, and the echo of a heartbeat already
+        # sent will never arrive, so fail pending pings rather than leaving them to time out
         if state in (
-            ConnectionState.DISCONNECTED,
             ConnectionState.SUSPENDED,
             ConnectionState.CLOSING,
             ConnectionState.CLOSED,
@@ -343,21 +359,43 @@ class ConnectionManager(EventEmitter):
             self.pending_message_queue.complete_all_messages(error)
 
     async def ping(self) -> float:
+        # RTN13b
         if self.__state not in (ConnectionState.CONNECTED, ConnectionState.CONNECTING):
             raise AblyException("Cannot send ping request. Calling ping in invalid state", 400, 40000)
 
         # RTN13e: the id tells this ping's echo apart from server heartbeats and other pings
-        ping_id = get_random_id()
-        echo = self.__pending_pings[ping_id] = asyncio.get_running_loop().create_future()
-        start_time = time.monotonic()
+        pending_ping = PendingPing(get_random_id())
+        self.__pending_pings[pending_ping.id] = pending_ping
         try:
-            await self.send_protocol_message({"action": ProtocolMessageAction.HEARTBEAT, "id": ping_id})
-            await asyncio.wait_for(echo, self.__timeout_in_secs)
+            # RTN13d: while connecting, the heartbeat goes out once the connection is established
+            if self.__state == ConnectionState.CONNECTED:
+                await self.__send_heartbeat(pending_ping)
+            # RTN13c
+            await asyncio.wait_for(pending_ping.future, self.__timeout_in_secs)
         except asyncio.TimeoutError:
             raise AblyException("Timeout waiting for ping response", 504, 50003) from None
         finally:
-            self.__pending_pings.pop(ping_id, None)
-        return round((time.monotonic() - start_time) * 1000, 2)
+            self.__pending_pings.pop(pending_ping.id, None)
+        return pending_ping.response_time_ms
+
+    async def __send_heartbeat(self, pending_ping: PendingPing) -> None:
+        pending_ping.start_time = time.monotonic()
+        try:
+            await self.send_protocol_message(pending_ping.message)
+        except Exception as error:
+            # the caller is waiting on the future, so the send failure is surfaced there
+            if not pending_ping.future.done():
+                pending_ping.future.set_exception(error)
+
+    def __send_pending_pings(self) -> None:
+        """RTN13d: send the heartbeat for each ping waiting on the connection
+
+        A ping registered while the connection was establishing has not sent its heartbeat yet,
+        and one whose heartbeat went out before the transport went away will never see that echo,
+        so both are (re)sent here and their round trip is measured from this point.
+        """
+        for pending_ping in list(self.__pending_pings.values()):
+            asyncio.create_task(self.__send_heartbeat(pending_ping))
 
     def on_connected(self, connection_details: ConnectionDetails, connection_id: str,
                      reason: AblyException | None = None) -> None:
@@ -461,16 +499,18 @@ class ConnectionManager(EventEmitter):
         self.__ably.channels._on_channel_message(msg)
 
     def on_heartbeat(self, id: str | None) -> None:
-        echo = self.__pending_pings.pop(id, None)
+        if id is None:
+            return
+        pending_ping = self.__pending_pings.pop(id, None)
         # the echo can arrive while wait_for is still cancelling a timed-out ping
-        if echo is not None and not echo.done():
-            echo.set_result(None)
+        if pending_ping is not None and not pending_ping.future.done():
+            pending_ping.future.set_result(None)
 
     def __fail_pending_pings(self, error: AblyException) -> None:
         pending, self.__pending_pings = self.__pending_pings, {}
-        for echo in pending.values():
-            if not echo.done():
-                echo.set_exception(error)
+        for pending_ping in pending.values():
+            if not pending_ping.future.done():
+                pending_ping.future.set_exception(error)
 
     def on_ack(
         self, serial: int, count: int, res: list[PublishResult] | None
@@ -637,6 +677,7 @@ class ConnectionManager(EventEmitter):
 
         if state == ConnectionState.CONNECTED:
             self.send_queued_messages()
+            self.__send_pending_pings()
         elif state in (
             ConnectionState.CLOSING,
             ConnectionState.CLOSED,

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -127,8 +127,8 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         assert ably.connection.state == ConnectionState.INITIALIZED
         with pytest.raises(AblyException) as exception:
             await ably.connection.ping()
-        assert exception.value.code == 400
-        assert exception.value.status_code == 40000
+        assert exception.value.code == 40000
+        assert exception.value.status_code == 400
 
     async def test_connection_ping_failed(self):
         ably = await TestApp.get_ably_realtime(key=self.valid_key_format)
@@ -136,8 +136,8 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         assert ably.connection.state == ConnectionState.FAILED
         with pytest.raises(AblyException) as exception:
             await ably.connection.ping()
-        assert exception.value.code == 400
-        assert exception.value.status_code == 40000
+        assert exception.value.code == 40000
+        assert exception.value.status_code == 400
         await ably.close()
 
     async def test_connection_ping_closed(self):
@@ -147,8 +147,8 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         await ably.close()
         with pytest.raises(AblyException) as exception:
             await ably.connection.ping()
-        assert exception.value.code == 400
-        assert exception.value.status_code == 40000
+        assert exception.value.code == 40000
+        assert exception.value.status_code == 400
 
     async def test_auto_connect(self):
         ably = await TestApp.get_ably_realtime()
@@ -212,6 +212,33 @@ class TestRealtimeConnection(BaseAsyncTestCase):
 
         assert exception.value.code == 50003
         assert exception.value.status_code == 504
+
+        # one timed-out ping must not break later pings
+        ably.connection.connection_manager.send_protocol_message = original_send_protocol_message
+        response_time_ms = await asyncio.wait_for(ably.connection.ping(), timeout=5)
+        assert type(response_time_ms) is float
+        await ably.close()
+
+    async def test_ping_after_invalid_state_ping(self):
+        # a ping rejected for bad state must not break later pings
+        ably = await TestApp.get_ably_realtime(auto_connect=False)
+        with pytest.raises(AblyException) as exception:
+            await ably.connection.ping()
+        assert exception.value.code == 40000
+
+        ably.connect()
+        await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=5)
+        response_time_ms = await asyncio.wait_for(ably.connection.ping(), timeout=5)
+        assert type(response_time_ms) is float
+        await ably.close()
+
+    async def test_concurrent_pings(self):
+        ably = await TestApp.get_ably_realtime()
+        await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=5)
+        results = await asyncio.wait_for(
+            asyncio.gather(ably.connection.ping(), ably.connection.ping(), ably.connection.ping()), timeout=5
+        )
+        assert all(type(response_time_ms) is float for response_time_ms in results)
         await ably.close()
 
     async def test_disconnected_retry_timeout(self):

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 import pytest
 from websockets import connect as _ws_connect
@@ -232,9 +233,10 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         assert type(response_time_ms) is float
         await ably.close()
 
-    async def test_ping_fails_immediately_when_connection_drops(self):
-        # a ping whose heartbeat is lost to a dropped connection must fail as soon as the
-        # connection is known to be down, not after realtime_request_timeout
+    async def test_ping_survives_connection_drop(self):
+        # RTN13d: a heartbeat lost with a dropped connection is sent again once the connection is
+        # back, rather than the ping failing or waiting out realtime_request_timeout
+        outage_secs = 1
         async with WsProxy(self.test_vars["host"]) as proxy:
             ably = await TestApp.get_ably_realtime(
                 realtime_request_timeout=20000,
@@ -253,26 +255,57 @@ class TestRealtimeConnection(BaseAsyncTestCase):
                     await original_send_protocol_message(protocol_message)
 
                 connection_manager.send_protocol_message = drop_heartbeats
+                ping_start_time = time.monotonic()
                 ping = asyncio.ensure_future(ably.connection.ping())
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(outage_secs)
                 assert not ping.done()
 
                 # Simulate server sending a normal WS close frame
+                connection_manager.send_protocol_message = original_send_protocol_message
                 await proxy.close_active_connection()
 
-                with pytest.raises(AblyException) as exception:
-                    await asyncio.wait_for(ping, timeout=5)
-                assert exception.value.code == 80003
-                assert exception.value.status_code == 400
-
-                # once reconnected, pings work again
-                connection_manager.send_protocol_message = original_send_protocol_message
-                if ably.connection.state != ConnectionState.CONNECTED:
-                    await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=10)
-                response_time_ms = await asyncio.wait_for(ably.connection.ping(), timeout=5)
+                response_time_ms = await asyncio.wait_for(ping, timeout=15)
+                elapsed_ms = (time.monotonic() - ping_start_time) * 1000
                 assert type(response_time_ms) is float
+                # the round trip is measured from the heartbeat that was sent on reconnection,
+                # so it excludes the time spent waiting for the connection
+                assert response_time_ms < elapsed_ms - outage_secs * 1000
             finally:
                 await ably.close()
+
+    async def test_ping_fails_when_connection_closes(self):
+        # RTN13b: a ping cannot complete once the connection has transitioned to CLOSING
+        ably = await TestApp.get_ably_realtime(realtime_request_timeout=20000)
+        await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=5)
+
+        connection_manager = ably.connection.connection_manager
+        original_send_protocol_message = connection_manager.send_protocol_message
+
+        async def drop_heartbeats(protocol_message):
+            if protocol_message.get('action') == ProtocolMessageAction.HEARTBEAT:
+                return
+            await original_send_protocol_message(protocol_message)
+
+        connection_manager.send_protocol_message = drop_heartbeats
+        ping = asyncio.ensure_future(ably.connection.ping())
+        await asyncio.sleep(0.5)
+        assert not ping.done()
+
+        await ably.close()
+
+        with pytest.raises(AblyException) as exception:
+            await asyncio.wait_for(ping, timeout=5)
+        assert exception.value.code == 80017
+        assert exception.value.status_code == 400
+
+    async def test_ping_while_connecting(self):
+        # RTN13d: a ping requested while connecting is done once the connection is established
+        ably = await TestApp.get_ably_realtime(auto_connect=False)
+        ably.connect()
+        assert ably.connection.state == ConnectionState.CONNECTING
+        response_time_ms = await asyncio.wait_for(ably.connection.ping(), timeout=15)
+        assert type(response_time_ms) is float
+        await ably.close()
 
     async def test_concurrent_pings(self):
         ably = await TestApp.get_ably_realtime()

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -232,6 +232,48 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         assert type(response_time_ms) is float
         await ably.close()
 
+    async def test_ping_fails_immediately_when_connection_drops(self):
+        # a ping whose heartbeat is lost to a dropped connection must fail as soon as the
+        # connection is known to be down, not after realtime_request_timeout
+        async with WsProxy(self.test_vars["host"]) as proxy:
+            ably = await TestApp.get_ably_realtime(
+                realtime_request_timeout=20000,
+                tls=False,
+                endpoint=proxy.endpoint,
+            )
+            try:
+                await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=10)
+
+                connection_manager = ably.connection.connection_manager
+                original_send_protocol_message = connection_manager.send_protocol_message
+
+                async def drop_heartbeats(protocol_message):
+                    if protocol_message.get('action') == ProtocolMessageAction.HEARTBEAT:
+                        return
+                    await original_send_protocol_message(protocol_message)
+
+                connection_manager.send_protocol_message = drop_heartbeats
+                ping = asyncio.ensure_future(ably.connection.ping())
+                await asyncio.sleep(0.5)
+                assert not ping.done()
+
+                # Simulate server sending a normal WS close frame
+                await proxy.close_active_connection()
+
+                with pytest.raises(AblyException) as exception:
+                    await asyncio.wait_for(ping, timeout=5)
+                assert exception.value.code == 80003
+                assert exception.value.status_code == 400
+
+                # once reconnected, pings work again
+                connection_manager.send_protocol_message = original_send_protocol_message
+                if ably.connection.state != ConnectionState.CONNECTED:
+                    await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=10)
+                response_time_ms = await asyncio.wait_for(ably.connection.ping(), timeout=5)
+                assert type(response_time_ms) is float
+            finally:
+                await ably.close()
+
     async def test_concurrent_pings(self):
         ably = await TestApp.get_ably_realtime()
         await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=5)


### PR DESCRIPTION
## Problem

- After one `ping()` timed out, `ConnectionManager.ping()` left the cancelled future in place. Every later `ping()` awaited it and failed instantly with `Ping request cancelled due to request timeout` (504/50003) for the life of the client, even though the connection was healthy and messages were flowing.
- A `ping()` rejected for being in an invalid state also left an unresolved future behind, so the next `ping()` after connecting hung forever.
- A ping whose heartbeat was lost to a dropped connection only failed once `realtime_request_timeout` expired.
- Seen in production: a client pinging every 5 s hit one lost heartbeat echo when its connection was moved between servers and resumed, then logged the cancelled error on every ping until restart (PUB-3865).

## Fix

- Each `ping()` tracks its own pending heartbeat by id (RTN13e) in `__pending_pings` and removes it in a `finally`, so success, timeout, send failure and caller cancellation all clean up and concurrent pings are independent.
- Pending pings are failed immediately when the connection leaves the connected state (DISCONNECTED, SUSPENDED, CLOSING, CLOSED, FAILED), with the state change reason or the matching `ConnectionErrors` entry (e.g. 80003), instead of waiting for the request timeout.
- Round trip time measured with a monotonic clock.
- The invalid-state error had code and status swapped (`400`/`40000`); now `code=40000`, `status_code=400`. Existing tests updated accordingly.

## Tests

- New: ping after a timeout sends a fresh heartbeat; ping after an invalid-state ping does not hang; concurrent pings all resolve; a ping in flight when the websocket is closed fails promptly with 80003 and pings work again after the reconnect.
- `test/ably/realtime` connection, auth and resume suites run locally against sandbox. `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ping reliability when multiple pings are in progress concurrently.
  - Pings requested while connecting now complete after the connection is established.
  - Pings interrupted by a dropped connection can survive reconnection and report round-trip time excluding the outage.
  - Pings now fail appropriately when the connection closes or enters an invalid state.
  - Fixed timeout and failed-ping cleanup so subsequent pings can succeed normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->