### PR TITLE
3.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [3.1.3](https://github.com/ably/ably-python/tree/v3.1.3)
+
+[Full Changelog](https://github.com/ably/ably-python/compare/v3.1.2...v3.1.3)
+
+### What's Changed
+
+- Fixed `ping()` so a timed-out, rejected, or connection-dropped ping no longer leaves a stale future behind that made every later `ping()` call fail or hang [#687](https://github.com/ably/ably-python/pull/687)
+- Annotation `data` is now encrypted on publish and decrypted on REST `get()` for channels with a cipher configured, instead of being sent in plaintext [#680](https://github.com/ably/ably-python/pull/680)
+- Fixed the "unable to attach" log to report the connection state that is blocking the attach rather than the channel state [#653](https://github.com/ably/ably-python/pull/653)
+
 ## [3.1.2](https://github.com/ably/ably-python/tree/v3.1.2)
 
 [Full Changelog](https://github.com/ably/ably-python/compare/v3.1.1...v3.1.2)

--- a/ably/__init__.py
+++ b/ably/__init__.py
@@ -21,4 +21,4 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 api_version = '5'
-lib_version = '3.1.2'
+lib_version = '3.1.3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ably"
-version = "3.1.2"
+version = "3.1.3"
 description = "Python REST and Realtime client library SDK for Ably realtime messaging service"
 readme = "LONG_DESCRIPTION.rst"
 requires-python = ">=3.7"

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "ably"
-version = "3.1.2"
+version = "3.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "h2", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
### What's Changed

- Fixed `ping()` so a timed-out, rejected, or connection-dropped ping no longer leaves a stale future behind that made every later `ping()` call fail or hang [#687](https://github.com/ably/ably-python/pull/687)
- Annotation `data` is now encrypted on publish and decrypted on REST `get()` for channels with a cipher configured, instead of being sent in plaintext [#680](https://github.com/ably/ably-python/pull/680)
- Fixed the "unable to attach" log to report the connection state that is blocking the attach rather than the channel state [#653](https://github.com/ably/ably-python/pull/653)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale ping operations.
  - Improved annotation encryption and decryption when custom ciphers are configured.
  - Updated attach logs to accurately report blocking connection status.

- **Release**
  - Updated the library to version 3.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->