### PR TITLE
fix: include the configured port in realtime websocket URLs

### DIFF
--- a/ably/transport/websockettransport.py
+++ b/ably/transport/websockettransport.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import msgpack
 
 from ably.http.httputils import HttpUtils
+from ably.transport.defaults import Defaults
 from ably.types.connectiondetails import ConnectionDetails
 from ably.types.operations import PublishResult
 from ably.util.eventemitter import EventEmitter
@@ -81,7 +82,8 @@ class WebSocketTransport(EventEmitter):
         headers = HttpUtils.default_headers()
         query_params = urllib.parse.urlencode(self.params)
         scheme = 'wss' if self.options.tls else 'ws'
-        ws_url = f'{scheme}://{self.host}?{query_params}'
+        port = Defaults.get_port(self.options)
+        ws_url = f'{scheme}://{self.host}:{port}?{query_params}'
         log.info(f'connect(): attempting to connect to {ws_url}')
         self.ws_connect_task = asyncio.create_task(self.ws_connect(ws_url, headers))
         self.ws_connect_task.add_done_callback(self.on_ws_connect_done)

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -67,8 +67,8 @@ class WsProxy:
 
     @property
     def endpoint(self) -> str:
-        """Endpoint string to pass to AblyRealtime (combine with tls=False)."""
-        return f"127.0.0.1:{self.port}"
+        """Host to pass to AblyRealtime (combine with tls=False and port=self.port)."""
+        return "127.0.0.1"
 
     async def __aenter__(self):
         self.server = await ws_serve(self._handler, "127.0.0.1", 0, ping_interval=None)
@@ -242,6 +242,7 @@ class TestRealtimeConnection(BaseAsyncTestCase):
                 realtime_request_timeout=20000,
                 tls=False,
                 endpoint=proxy.endpoint,
+                port=proxy.port,
             )
             try:
                 await asyncio.wait_for(ably.connection.once_async(ConnectionState.CONNECTED), timeout=10)
@@ -654,6 +655,7 @@ class TestRealtimeConnection(BaseAsyncTestCase):
                 suspended_retry_timeout=500_000,
                 tls=False,
                 endpoint=proxy.endpoint,
+                port=proxy.port,
             )
 
             try:

--- a/test/unit/websockettransport_test.py
+++ b/test/unit/websockettransport_test.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+from ably.transport.websockettransport import WebSocketTransport
+from ably.types.options import Options
+
+
+def _connect_url(host='example.com', **option_kwargs):
+    connection_manager = MagicMock()
+    connection_manager.options = Options(auth_token='foo', **option_kwargs)
+    transport = WebSocketTransport(connection_manager, host, {'format': 'json'})
+    with patch.object(transport, 'ws_connect', MagicMock()) as mock_ws_connect:
+        with patch('ably.transport.websockettransport.asyncio.create_task') as mock_create_task:
+            mock_create_task.return_value = MagicMock()
+            transport.connect()
+    return mock_ws_connect.call_args[0][0]
+
+
+# TO3d, TO3o
+def test_websocket_url_uses_wss_and_tls_port_when_tls_enabled():
+    url = _connect_url(tls=True, tls_port=9999)
+    assert url == 'wss://example.com:9999?format=json'
+
+
+# TO3d, TO3n
+def test_websocket_url_uses_ws_and_port_when_tls_disabled():
+    url = _connect_url(tls=False, port=9998)
+    assert url == 'ws://example.com:9998?format=json'
+
+
+# TO3d, TO3o
+def test_websocket_url_defaults_to_wss_and_443():
+    url = _connect_url()
+    assert url == 'wss://example.com:443?format=json'
+
+
+# TO3d, TO3n
+def test_websocket_url_defaults_to_ws_and_80_when_tls_disabled():
+    url = _connect_url(tls=False)
+    assert url == 'ws://example.com:80?format=json'


### PR DESCRIPTION
## Summary

Append `Defaults.get_port(options)` to the realtime websocket URL, the same helper REST already uses for `host:port`. Realtime websocket URLs already honoured `tls` (`ws` vs `wss`) but ignored `port` / `tls_port`, so a custom listener never received the connection.

Closes #567.

## Provenance

The issue pointed at `WebSocketTransport.connect()` hardcoding `wss://` (`websockettransport.py` L58 at `a38fb036`). `tls` is already applied to the scheme on current main. REST has included `Defaults.get_port` for years (`Http.make_request`: `f"{scheme}://{host}:{preferred_port}"`). ably-js does the same for websocket: `wsScheme + wsHost + ':' + Defaults.getPort(options) + '/'`.

## Decision

Always append `:{port}` via `Defaults.get_port`, including 80/443. That matches REST in this repo and ably-js. Alternative: append only a non-default port (production URLs stay as they are today). Can omit default 80/443 if you would rather keep production URLs unchanged.

Existing local-proxy tests that had put the port in `endpoint` (`127.0.0.1:{port}`) now pass `port=` instead, so they would not become `host:proxyport:80`. Anyone who used `endpoint="host:port"` as a workaround for this bug should switch to `port` / `tls_port`.

## Test plan

- [x] `test/unit/websockettransport_test.py` fails without the port on the URL (`wss://example.com?format=json` vs `wss://example.com:9999?format=json`, and the `ws` / default 80/443 cases)
- [x] The same tests pass with the port included
- [x] `test_ping_survives_connection_drop` and `test_normal_ws_close_triggers_immediate_reconnection` still pass with `tls=False` and `port=` pointing at the local proxy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - WebSocket connections now use the configured port when establishing secure or non-secure connections.
  - Custom TLS and non-TLS ports are correctly reflected in connection URLs.
  - Default ports remain supported: 443 for secure WebSockets and 80 for non-secure WebSockets.
  - Proxy connections now handle dynamically assigned ports correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->